### PR TITLE
rightscale -> terraform-providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,99 +1,99 @@
 # Change Log
 
-## [v1.3.0](https://github.com/rightscale/terraform-provider-rightscale/tree/v1.3.0) (2018-06-20)
-[Full Changelog](https://github.com/rightscale/terraform-provider-rightscale/compare/v1.2.1...v1.3.0)
+## [v1.3.0](https://github.com/terraform-providers/terraform-provider-rightscale/tree/v1.3.0) (2018-06-20)
+[Full Changelog](https://github.com/terraform-providers/terraform-provider-rightscale/compare/v1.2.1...v1.3.0)
 
 **Merged pull requests:**
 
-- STEEL-288 Retry API requests [\#68](https://github.com/rightscale/terraform-provider-rightscale/pull/68) ([crunis](https://github.com/crunis))
-- STEEL-296 Update documentation about href field [\#67](https://github.com/rightscale/terraform-provider-rightscale/pull/67) ([crunis](https://github.com/crunis))
-- STEEL-293 add datasource tests, add namespace to datasource id [\#64](https://github.com/rightscale/terraform-provider-rightscale/pull/64) ([crunis](https://github.com/crunis))
+- STEEL-288 Retry API requests [\#68](https://github.com/terraform-providers/terraform-provider-rightscale/pull/68) ([crunis](https://github.com/crunis))
+- STEEL-296 Update documentation about href field [\#67](https://github.com/terraform-providers/terraform-provider-rightscale/pull/67) ([crunis](https://github.com/crunis))
+- STEEL-293 add datasource tests, add namespace to datasource id [\#64](https://github.com/terraform-providers/terraform-provider-rightscale/pull/64) ([crunis](https://github.com/crunis))
 
-## [v1.2.1](https://github.com/rightscale/terraform-provider-rightscale/tree/v1.2.1) (2018-06-15)
-[Full Changelog](https://github.com/rightscale/terraform-provider-rightscale/compare/v1.2.0...v1.2.1)
+## [v1.2.1](https://github.com/terraform-providers/terraform-provider-rightscale/tree/v1.2.1) (2018-06-15)
+[Full Changelog](https://github.com/terraform-providers/terraform-provider-rightscale/compare/v1.2.0...v1.2.1)
 
 **Merged pull requests:**
 
-- STEEL-296 Add href field to datasources [\#65](https://github.com/rightscale/terraform-provider-rightscale/pull/65) ([crunis](https://github.com/crunis))
+- STEEL-296 Add href field to datasources [\#65](https://github.com/terraform-providers/terraform-provider-rightscale/pull/65) ([crunis](https://github.com/crunis))
 
-## [v1.2.0](https://github.com/rightscale/terraform-provider-rightscale/tree/v1.2.0) (2018-06-13)
-[Full Changelog](https://github.com/rightscale/terraform-provider-rightscale/compare/v1.1.0...v1.2.0)
+## [v1.2.0](https://github.com/terraform-providers/terraform-provider-rightscale/tree/v1.2.0) (2018-06-13)
+[Full Changelog](https://github.com/terraform-providers/terraform-provider-rightscale/compare/v1.1.0...v1.2.0)
 
 **Closed issues:**
 
-- Terraform Provider Development Program - Initial Review [\#60](https://github.com/rightscale/terraform-provider-rightscale/issues/60)
+- Terraform Provider Development Program - Initial Review [\#60](https://github.com/terraform-providers/terraform-provider-rightscale/issues/60)
 
 **Merged pull requests:**
 
-- STEEL-285 Add tests for more CWF parameter types [\#63](https://github.com/rightscale/terraform-provider-rightscale/pull/63) ([crunis](https://github.com/crunis))
-- STEEL-260 Provider Hashicorp Acceptance Modifications [\#61](https://github.com/rightscale/terraform-provider-rightscale/pull/61) ([mastamark](https://github.com/mastamark))
-- STEEL-290 Changing CWF "array" type to entity [\#59](https://github.com/rightscale/terraform-provider-rightscale/pull/59) ([crunis](https://github.com/crunis))
-- STEEL-284 CWF Process Documentation fix [\#58](https://github.com/rightscale/terraform-provider-rightscale/pull/58) ([crunis](https://github.com/crunis))
-- STEEL-281 Fix server delete [\#57](https://github.com/rightscale/terraform-provider-rightscale/pull/57) ([crunis](https://github.com/crunis))
-- STEEL-277 Clean up code [\#56](https://github.com/rightscale/terraform-provider-rightscale/pull/56) ([crunis](https://github.com/crunis))
-- STEEL-283 'private\_ip\_address' for instance now added as a field so… [\#55](https://github.com/rightscale/terraform-provider-rightscale/pull/55) ([mastamark](https://github.com/mastamark))
-- STEEL-236 resource tags [\#54](https://github.com/rightscale/terraform-provider-rightscale/pull/54) ([mastamark](https://github.com/mastamark))
-- STEEL-278 rescue retries and cloud polling [\#53](https://github.com/rightscale/terraform-provider-rightscale/pull/53) ([mastamark](https://github.com/mastamark))
-- STEEL-109 Add more rsc tests [\#52](https://github.com/rightscale/terraform-provider-rightscale/pull/52) ([crunis](https://github.com/crunis))
-- STEEL-276 Fix SecurityGroup doc [\#51](https://github.com/rightscale/terraform-provider-rightscale/pull/51) ([crunis](https://github.com/crunis))
-- STEEL-270 custom provision functions [\#50](https://github.com/rightscale/terraform-provider-rightscale/pull/50) ([mastamark](https://github.com/mastamark))
+- STEEL-285 Add tests for more CWF parameter types [\#63](https://github.com/terraform-providers/terraform-provider-rightscale/pull/63) ([crunis](https://github.com/crunis))
+- STEEL-260 Provider Hashicorp Acceptance Modifications [\#61](https://github.com/terraform-providers/terraform-provider-rightscale/pull/61) ([mastamark](https://github.com/mastamark))
+- STEEL-290 Changing CWF "array" type to entity [\#59](https://github.com/terraform-providers/terraform-provider-rightscale/pull/59) ([crunis](https://github.com/crunis))
+- STEEL-284 CWF Process Documentation fix [\#58](https://github.com/terraform-providers/terraform-provider-rightscale/pull/58) ([crunis](https://github.com/crunis))
+- STEEL-281 Fix server delete [\#57](https://github.com/terraform-providers/terraform-provider-rightscale/pull/57) ([crunis](https://github.com/crunis))
+- STEEL-277 Clean up code [\#56](https://github.com/terraform-providers/terraform-provider-rightscale/pull/56) ([crunis](https://github.com/crunis))
+- STEEL-283 'private\_ip\_address' for instance now added as a field so… [\#55](https://github.com/terraform-providers/terraform-provider-rightscale/pull/55) ([mastamark](https://github.com/mastamark))
+- STEEL-236 resource tags [\#54](https://github.com/terraform-providers/terraform-provider-rightscale/pull/54) ([mastamark](https://github.com/mastamark))
+- STEEL-278 rescue retries and cloud polling [\#53](https://github.com/terraform-providers/terraform-provider-rightscale/pull/53) ([mastamark](https://github.com/mastamark))
+- STEEL-109 Add more rsc tests [\#52](https://github.com/terraform-providers/terraform-provider-rightscale/pull/52) ([crunis](https://github.com/crunis))
+- STEEL-276 Fix SecurityGroup doc [\#51](https://github.com/terraform-providers/terraform-provider-rightscale/pull/51) ([crunis](https://github.com/crunis))
+- STEEL-270 custom provision functions [\#50](https://github.com/terraform-providers/terraform-provider-rightscale/pull/50) ([mastamark](https://github.com/mastamark))
 
-## [v1.1.0](https://github.com/rightscale/terraform-provider-rightscale/tree/v1.1.0) (2018-05-18)
-[Full Changelog](https://github.com/rightscale/terraform-provider-rightscale/compare/v1.0.0...v1.1.0)
+## [v1.1.0](https://github.com/terraform-providers/terraform-provider-rightscale/tree/v1.1.0) (2018-05-18)
+[Full Changelog](https://github.com/terraform-providers/terraform-provider-rightscale/compare/v1.0.0...v1.1.0)
 
 **Merged pull requests:**
 
-- STEEL-262 Ensure acceptance tests concurrency [\#49](https://github.com/rightscale/terraform-provider-rightscale/pull/49) ([crunis](https://github.com/crunis))
-- STEEL-239 server resource needs inputs to be useful [\#48](https://github.com/rightscale/terraform-provider-rightscale/pull/48) ([mastamark](https://github.com/mastamark))
-- STEEL-258 Fix Sec Group Rule Race Cond in Tests [\#45](https://github.com/rightscale/terraform-provider-rightscale/pull/45) ([crunis](https://github.com/crunis))
+- STEEL-262 Ensure acceptance tests concurrency [\#49](https://github.com/terraform-providers/terraform-provider-rightscale/pull/49) ([crunis](https://github.com/crunis))
+- STEEL-239 server resource needs inputs to be useful [\#48](https://github.com/terraform-providers/terraform-provider-rightscale/pull/48) ([mastamark](https://github.com/mastamark))
+- STEEL-258 Fix Sec Group Rule Race Cond in Tests [\#45](https://github.com/terraform-providers/terraform-provider-rightscale/pull/45) ([crunis](https://github.com/crunis))
 
-## [v1.0.0](https://github.com/rightscale/terraform-provider-rightscale/tree/v1.0.0) (2018-05-08)
-[Full Changelog](https://github.com/rightscale/terraform-provider-rightscale/compare/v0.0.1-alpha...v1.0.0)
+## [v1.0.0](https://github.com/terraform-providers/terraform-provider-rightscale/tree/v1.0.0) (2018-05-08)
+[Full Changelog](https://github.com/terraform-providers/terraform-provider-rightscale/compare/v0.0.1-alpha...v1.0.0)
 
 **Closed issues:**
 
-- Need RightScale Credential object support [\#20](https://github.com/rightscale/terraform-provider-rightscale/issues/20)
+- Need RightScale Credential object support [\#20](https://github.com/terraform-providers/terraform-provider-rightscale/issues/20)
 
 **Merged pull requests:**
 
-- STEEL-90 Adding route resource [\#43](https://github.com/rightscale/terraform-provider-rightscale/pull/43) ([mastamark](https://github.com/mastamark))
-- STEEL-76 server\_array resource [\#42](https://github.com/rightscale/terraform-provider-rightscale/pull/42) ([crunis](https://github.com/crunis))
-- STEEL-91 route table [\#41](https://github.com/rightscale/terraform-provider-rightscale/pull/41) ([mastamark](https://github.com/mastamark))
-- STEEL-255 use vpc networks for tests so we can use newer instance types [\#40](https://github.com/rightscale/terraform-provider-rightscale/pull/40) ([mastamark](https://github.com/mastamark))
-- STEEL-89 subnet resource and datasource [\#39](https://github.com/rightscale/terraform-provider-rightscale/pull/39) ([mastamark](https://github.com/mastamark))
-- STEEL-78 security group rule resource [\#38](https://github.com/rightscale/terraform-provider-rightscale/pull/38) ([mastamark](https://github.com/mastamark))
-- STEEL-77 security group resource and datasource polished and tests written [\#37](https://github.com/rightscale/terraform-provider-rightscale/pull/37) ([mastamark](https://github.com/mastamark))
-- STEEL-256 fix defaulting behavior for deployment resource and tag s… [\#36](https://github.com/rightscale/terraform-provider-rightscale/pull/36) ([mastamark](https://github.com/mastamark))
-- STEEL-92 network gateway resource fixed up, tests written and docum… [\#35](https://github.com/rightscale/terraform-provider-rightscale/pull/35) ([mastamark](https://github.com/mastamark))
-- STEEL-88 network resource, docs and tests [\#34](https://github.com/rightscale/terraform-provider-rightscale/pull/34) ([mastamark](https://github.com/mastamark))
-- STEEL-248 datacenter docs [\#33](https://github.com/rightscale/terraform-provider-rightscale/pull/33) ([crunis](https://github.com/crunis))
-- STEEL-249 multi cloud image docs [\#32](https://github.com/rightscale/terraform-provider-rightscale/pull/32) ([crunis](https://github.com/crunis))
-- STEEL-250 server template docs [\#31](https://github.com/rightscale/terraform-provider-rightscale/pull/31) ([crunis](https://github.com/crunis))
-- STEEL-251 Volume Snapshot Documentation [\#30](https://github.com/rightscale/terraform-provider-rightscale/pull/30) ([crunis](https://github.com/crunis))
-- STEEL-237 Instance documentation [\#29](https://github.com/rightscale/terraform-provider-rightscale/pull/29) ([crunis](https://github.com/crunis))
-- STEEL-252 volume\_type datasource verified and docs added [\#28](https://github.com/rightscale/terraform-provider-rightscale/pull/28) ([mastamark](https://github.com/mastamark))
-- STEEL-238 image and instance type datasource verify and document [\#27](https://github.com/rightscale/terraform-provider-rightscale/pull/27) ([mastamark](https://github.com/mastamark))
-- STEEL-232 substitute travis\_wait [\#26](https://github.com/rightscale/terraform-provider-rightscale/pull/26) ([crunis](https://github.com/crunis))
-- STEEL-227 deployment resource and datasource [\#24](https://github.com/rightscale/terraform-provider-rightscale/pull/24) ([mastamark](https://github.com/mastamark))
-- STEEL-95 resource\_cwf\_process improvements [\#23](https://github.com/rightscale/terraform-provider-rightscale/pull/23) ([crunis](https://github.com/crunis))
+- STEEL-90 Adding route resource [\#43](https://github.com/terraform-providers/terraform-provider-rightscale/pull/43) ([mastamark](https://github.com/mastamark))
+- STEEL-76 server\_array resource [\#42](https://github.com/terraform-providers/terraform-provider-rightscale/pull/42) ([crunis](https://github.com/crunis))
+- STEEL-91 route table [\#41](https://github.com/terraform-providers/terraform-provider-rightscale/pull/41) ([mastamark](https://github.com/mastamark))
+- STEEL-255 use vpc networks for tests so we can use newer instance types [\#40](https://github.com/terraform-providers/terraform-provider-rightscale/pull/40) ([mastamark](https://github.com/mastamark))
+- STEEL-89 subnet resource and datasource [\#39](https://github.com/terraform-providers/terraform-provider-rightscale/pull/39) ([mastamark](https://github.com/mastamark))
+- STEEL-78 security group rule resource [\#38](https://github.com/terraform-providers/terraform-provider-rightscale/pull/38) ([mastamark](https://github.com/mastamark))
+- STEEL-77 security group resource and datasource polished and tests written [\#37](https://github.com/terraform-providers/terraform-provider-rightscale/pull/37) ([mastamark](https://github.com/mastamark))
+- STEEL-256 fix defaulting behavior for deployment resource and tag s… [\#36](https://github.com/terraform-providers/terraform-provider-rightscale/pull/36) ([mastamark](https://github.com/mastamark))
+- STEEL-92 network gateway resource fixed up, tests written and docum… [\#35](https://github.com/terraform-providers/terraform-provider-rightscale/pull/35) ([mastamark](https://github.com/mastamark))
+- STEEL-88 network resource, docs and tests [\#34](https://github.com/terraform-providers/terraform-provider-rightscale/pull/34) ([mastamark](https://github.com/mastamark))
+- STEEL-248 datacenter docs [\#33](https://github.com/terraform-providers/terraform-provider-rightscale/pull/33) ([crunis](https://github.com/crunis))
+- STEEL-249 multi cloud image docs [\#32](https://github.com/terraform-providers/terraform-provider-rightscale/pull/32) ([crunis](https://github.com/crunis))
+- STEEL-250 server template docs [\#31](https://github.com/terraform-providers/terraform-provider-rightscale/pull/31) ([crunis](https://github.com/crunis))
+- STEEL-251 Volume Snapshot Documentation [\#30](https://github.com/terraform-providers/terraform-provider-rightscale/pull/30) ([crunis](https://github.com/crunis))
+- STEEL-237 Instance documentation [\#29](https://github.com/terraform-providers/terraform-provider-rightscale/pull/29) ([crunis](https://github.com/crunis))
+- STEEL-252 volume\_type datasource verified and docs added [\#28](https://github.com/terraform-providers/terraform-provider-rightscale/pull/28) ([mastamark](https://github.com/mastamark))
+- STEEL-238 image and instance type datasource verify and document [\#27](https://github.com/terraform-providers/terraform-provider-rightscale/pull/27) ([mastamark](https://github.com/mastamark))
+- STEEL-232 substitute travis\_wait [\#26](https://github.com/terraform-providers/terraform-provider-rightscale/pull/26) ([crunis](https://github.com/crunis))
+- STEEL-227 deployment resource and datasource [\#24](https://github.com/terraform-providers/terraform-provider-rightscale/pull/24) ([mastamark](https://github.com/mastamark))
+- STEEL-95 resource\_cwf\_process improvements [\#23](https://github.com/terraform-providers/terraform-provider-rightscale/pull/23) ([crunis](https://github.com/crunis))
 
-## [v0.0.1-alpha](https://github.com/rightscale/terraform-provider-rightscale/tree/v0.0.1-alpha) (2018-02-15)
+## [v0.0.1-alpha](https://github.com/terraform-providers/terraform-provider-rightscale/tree/v0.0.1-alpha) (2018-02-15)
 **Merged pull requests:**
 
-- STEEL-85 Terraform Credential resource with tests and docs [\#19](https://github.com/rightscale/terraform-provider-rightscale/pull/19) ([mastamark](https://github.com/mastamark))
-- STEEL-160 Add server data source [\#18](https://github.com/rightscale/terraform-provider-rightscale/pull/18) ([bill-rich](https://github.com/bill-rich))
-- STEEL-79 Volume DataSource Documentation [\#17](https://github.com/rightscale/terraform-provider-rightscale/pull/17) ([crunis](https://github.com/crunis))
-- STEEL-149 Use random string for functional test [\#15](https://github.com/rightscale/terraform-provider-rightscale/pull/15) ([adamalex](https://github.com/adamalex))
-- STEEL-75 Fix up server resource and add tests and docs [\#14](https://github.com/rightscale/terraform-provider-rightscale/pull/14) ([bill-rich](https://github.com/bill-rich))
-- STEEL-121 tf datasources implement views [\#12](https://github.com/rightscale/terraform-provider-rightscale/pull/12) ([mark-dotson-rs](https://github.com/mark-dotson-rs))
-- STEEL-132 Add unpopulated field filter [\#11](https://github.com/rightscale/terraform-provider-rightscale/pull/11) ([bill-rich](https://github.com/bill-rich))
-- STEEL-74 Review Prep [\#10](https://github.com/rightscale/terraform-provider-rightscale/pull/10) ([adamalex](https://github.com/adamalex))
-- STEEL-84 terraform rs ssh key resource tests and docs [\#9](https://github.com/rightscale/terraform-provider-rightscale/pull/9) ([mark-dotson-rs](https://github.com/mark-dotson-rs))
-- STEEL-120 Modify cmFilters function to properly format filter strin… [\#8](https://github.com/rightscale/terraform-provider-rightscale/pull/8) ([mark-dotson-rs](https://github.com/mark-dotson-rs))
-- STEEL-107 fix output race condition [\#7](https://github.com/rightscale/terraform-provider-rightscale/pull/7) ([adamalex](https://github.com/adamalex))
-- STEEL-73 get repo using dep for dependenency management [\#3](https://github.com/rightscale/terraform-provider-rightscale/pull/3) ([mark-dotson-rs](https://github.com/mark-dotson-rs))
-- STEEL-62 Fix cm instance resource and add tests [\#2](https://github.com/rightscale/terraform-provider-rightscale/pull/2) ([bill-rich](https://github.com/bill-rich))
-- STEEL-60 Improve error messages for rsc client [\#1](https://github.com/rightscale/terraform-provider-rightscale/pull/1) ([bill-rich](https://github.com/bill-rich))
+- STEEL-85 Terraform Credential resource with tests and docs [\#19](https://github.com/terraform-providers/terraform-provider-rightscale/pull/19) ([mastamark](https://github.com/mastamark))
+- STEEL-160 Add server data source [\#18](https://github.com/terraform-providers/terraform-provider-rightscale/pull/18) ([bill-rich](https://github.com/bill-rich))
+- STEEL-79 Volume DataSource Documentation [\#17](https://github.com/terraform-providers/terraform-provider-rightscale/pull/17) ([crunis](https://github.com/crunis))
+- STEEL-149 Use random string for functional test [\#15](https://github.com/terraform-providers/terraform-provider-rightscale/pull/15) ([adamalex](https://github.com/adamalex))
+- STEEL-75 Fix up server resource and add tests and docs [\#14](https://github.com/terraform-providers/terraform-provider-rightscale/pull/14) ([bill-rich](https://github.com/bill-rich))
+- STEEL-121 tf datasources implement views [\#12](https://github.com/terraform-providers/terraform-provider-rightscale/pull/12) ([mark-dotson-rs](https://github.com/mark-dotson-rs))
+- STEEL-132 Add unpopulated field filter [\#11](https://github.com/terraform-providers/terraform-provider-rightscale/pull/11) ([bill-rich](https://github.com/bill-rich))
+- STEEL-74 Review Prep [\#10](https://github.com/terraform-providers/terraform-provider-rightscale/pull/10) ([adamalex](https://github.com/adamalex))
+- STEEL-84 terraform rs ssh key resource tests and docs [\#9](https://github.com/terraform-providers/terraform-provider-rightscale/pull/9) ([mark-dotson-rs](https://github.com/mark-dotson-rs))
+- STEEL-120 Modify cmFilters function to properly format filter strin… [\#8](https://github.com/terraform-providers/terraform-provider-rightscale/pull/8) ([mark-dotson-rs](https://github.com/mark-dotson-rs))
+- STEEL-107 fix output race condition [\#7](https://github.com/terraform-providers/terraform-provider-rightscale/pull/7) ([adamalex](https://github.com/adamalex))
+- STEEL-73 get repo using dep for dependenency management [\#3](https://github.com/terraform-providers/terraform-provider-rightscale/pull/3) ([mark-dotson-rs](https://github.com/mark-dotson-rs))
+- STEEL-62 Fix cm instance resource and add tests [\#2](https://github.com/terraform-providers/terraform-provider-rightscale/pull/2) ([bill-rich](https://github.com/bill-rich))
+- STEEL-60 Improve error messages for rsc client [\#1](https://github.com/terraform-providers/terraform-provider-rightscale/pull/1) ([bill-rich](https://github.com/bill-rich))
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ terraform-provider-rightscale
 This is the Terraform provider for RightScale.  Acceptance into the terraform community and as an official provider is now in progress, but as of this version all tests, docs, and sufficient resources for full operational coverage is complete and tested. [ Note that instructions below are forward-looking for where this repo will move in the near future. ]
 
 Markdown (Documentation) is available here:
-- [Resources](https://github.com/rightscale/terraform-provider-rightscale/tree/master/website/docs/r)
-- [Datasources](https://github.com/rightscale/terraform-provider-rightscale/tree/master/website/docs/d)
+- [Resources](https://github.com/terraform-providers/terraform-provider-rightscale/tree/master/website/docs/r)
+- [Datasources](https://github.com/terraform-providers/terraform-provider-rightscale/tree/master/website/docs/d)
 
-Please [open an issue](https://github.com/rightscale/terraform-provider-rightscale/issues/new) if you find a bug or otherwise are interested in contributing to this open source effort.  PRs accepted!
+Please [open an issue](https://github.com/terraform-providers/terraform-provider-rightscale/issues/new) if you find a bug or otherwise are interested in contributing to this open source effort.  PRs accepted!
 
 Terraform Provider
 ==================
@@ -45,7 +45,7 @@ $ make build
 Using the provider
 ----------------------
 
-See the [RightScale Provider documentation](https://github.com/rightscale/terraform-provider-rightscale/blob/master/website/docs/index.html.markdown) to get started using the RightScale provider.
+See the [RightScale Provider documentation](https://github.com/terraform-providers/terraform-provider-rightscale/blob/master/website/docs/index.html.markdown) to get started using the RightScale provider.
 
 Developing the Provider
 ---------------------------

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	rs "github.com/rightscale/terraform-provider-rightscale/rightscale"
+	rs "github.com/terraform-providers/terraform-provider-rightscale/rightscale"
 )
 
 func main() {

--- a/rightscale/cm_helpers.go
+++ b/rightscale/cm_helpers.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // cmUIDSet is a helper function that returns true or false if 'resource_uid' is set as part

--- a/rightscale/data_source_cloud.go
+++ b/rightscale/data_source_cloud.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_credential.go
+++ b/rightscale/data_source_credential.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_datacenter.go
+++ b/rightscale/data_source_datacenter.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_deployment.go
+++ b/rightscale/data_source_deployment.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_image.go
+++ b/rightscale/data_source_image.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_instance.go
+++ b/rightscale/data_source_instance.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Examples:

--- a/rightscale/data_source_instance_type.go
+++ b/rightscale/data_source_instance_type.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_multi_cloud_image.go
+++ b/rightscale/data_source_multi_cloud_image.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_network.go
+++ b/rightscale/data_source_network.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_network_gateway.go
+++ b/rightscale/data_source_network_gateway.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_route_table.go
+++ b/rightscale/data_source_route_table.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_security_group.go
+++ b/rightscale/data_source_security_group.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_server.go
+++ b/rightscale/data_source_server.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_server_template.go
+++ b/rightscale/data_source_server_template.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_ssh_key.go
+++ b/rightscale/data_source_ssh_key.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_subnet.go
+++ b/rightscale/data_source_subnet.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_volume.go
+++ b/rightscale/data_source_volume.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_volume_snapshot.go
+++ b/rightscale/data_source_volume_snapshot.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/data_source_volume_type.go
+++ b/rightscale/data_source_volume_type.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/provider.go
+++ b/rightscale/provider.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Provider returns the RightScale terraform provider.

--- a/rightscale/resource.go
+++ b/rightscale/resource.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 func resourceCreateFunc(namespace, typ string, fieldsFunc func(*schema.ResourceData) rsc.Fields) func(*schema.ResourceData, interface{}) error {

--- a/rightscale/resource_credential.go
+++ b/rightscale/resource_credential.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_cwf_process.go
+++ b/rightscale/resource_cwf_process.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 func resourceCWFProcess() *schema.Resource {

--- a/rightscale/resource_cwf_process_test.go
+++ b/rightscale/resource_cwf_process_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 func TestAccRightScaleCWFProcess_basic(t *testing.T) {

--- a/rightscale/resource_deployment.go
+++ b/rightscale/resource_deployment.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_instance.go
+++ b/rightscale/resource_instance.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // resource "rightscale_instance" "my_instance" {

--- a/rightscale/resource_network.go
+++ b/rightscale/resource_network.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_network_gateway.go
+++ b/rightscale/resource_network_gateway.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_route.go
+++ b/rightscale/resource_route.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_route_table.go
+++ b/rightscale/resource_route_table.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_security_group.go
+++ b/rightscale/resource_security_group.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_security_group_rule.go
+++ b/rightscale/resource_security_group_rule.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_server.go
+++ b/rightscale/resource_server.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_server_array.go
+++ b/rightscale/resource_server_array.go
@@ -3,7 +3,7 @@ package rightscale
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_ssh_key.go
+++ b/rightscale/resource_ssh_key.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/rightscale/resource_subnet.go
+++ b/rightscale/resource_subnet.go
@@ -2,7 +2,7 @@ package rightscale
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+	"github.com/terraform-providers/terraform-provider-rightscale/rightscale/rsc"
 )
 
 // Example:

--- a/website/docs/d/cm_cloud.markdown
+++ b/website/docs/d/cm_cloud.markdown
@@ -41,7 +41,7 @@ The `filter` block supports:
 
 * `description` - (Optional) Cloud description as displayed in cm platform.  Pattern match.
 
-* `cloud_type` - (Optional) Cloud type as referenced in cm platform.  Common types include: amazon, google, azure, and vscale.  See  [supportedCloudTypes](https://github.com/rightscale/terraform-provider-rightscale/blob/master/rightscale/data_source_cloud.go#L95) for complete list.
+* `cloud_type` - (Optional) Cloud type as referenced in cm platform.  Common types include: amazon, google, azure, and vscale.  See  [supportedCloudTypes](https://github.com/terraform-providers/terraform-provider-rightscale/blob/master/rightscale/data_source_cloud.go#L95) for complete list.
 
 ## Attributes Reference
 

--- a/website/docs/d/cm_server.markdown
+++ b/website/docs/d/cm_server.markdown
@@ -55,7 +55,7 @@ The following attributes are exported:
 
 * `description` - A description of the server
 
-* `instance` - See [rightscale_instance](https://github.com/rightscale/terraform-provider-rightscale/blob/master/rightscale/website/docs/r/cm_server.markdown)
+* `instance` - See [rightscale_instance](https://github.com/terraform-providers/terraform-provider-rightscale/blob/master/rightscale/website/docs/r/cm_server.markdown)
 
 * `optimized` - A flag indicating whether instances of this server should be optimized for high-performance volumes
 

--- a/website/docs/r/cm_instance.markdown
+++ b/website/docs/r/cm_instance.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `server_template_href` - (Optional) The href of the instance server template resource.
 
-* `inputs` - (Optional) Inputs associated with an instance when incarnated from a [server](https://github.com/rightscale/terraform-provider-rightscale/blob/master/website/docs/r/cm_server.markdown) or [server_array](https://github.com/rightscale/terraform-provider-rightscale/blob/master/website/docs/r/cm_server_array.markdown).
+* `inputs` - (Optional) Inputs associated with an instance when incarnated from a [server](https://github.com/terraform-providers/terraform-provider-rightscale/blob/master/website/docs/r/cm_server.markdown) or [server_array](https://github.com/terraform-providers/terraform-provider-rightscale/blob/master/website/docs/r/cm_server_array.markdown).
 
 * `associate_public_ip_address` - (Optional) Indicates if the instance will get a Public IP address.
 

--- a/website/docs/r/cm_server.markdown
+++ b/website/docs/r/cm_server.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `deployment_href` - (Required) The href of the deployment the server will be placed in.
 
-* `instance` - (Required) See [rightscale_instance](https://github.com/rightscale/terraform-provider-rightscale/blob/master/website/docs/r/cm_instance.markdown)
+* `instance` - (Required) See [rightscale_instance](https://github.com/terraform-providers/terraform-provider-rightscale/blob/master/website/docs/r/cm_instance.markdown)
 
 * `cloud_href` - (Required) The Href of the cloud the server will be launched in.
 

--- a/website/docs/r/cm_server_array.markdown
+++ b/website/docs/r/cm_server_array.markdown
@@ -127,7 +127,7 @@ The following arguments are supported:
 
   * `time` - (Required) Specifies the time when an alert-based array resizes.
 
-* `instance` - (Required) See [rightscale_instance](https://github.com/rightscale/terraform-provider-rightscale/blob/master/rightscale/website/docs/r/cm_instance.markdown)
+* `instance` - (Required) See [rightscale_instance](https://github.com/terraform-providers/terraform-provider-rightscale/blob/master/rightscale/website/docs/r/cm_instance.markdown)
 
 
 ## Attribute Reference


### PR DESCRIPTION
Replacing old `rightscale` path with new `terraform-providers/` location.