### PR TITLE
Resource rightscale_server: remove invalid key

### DIFF
--- a/website/docs/r/cm_server.markdown
+++ b/website/docs/r/cm_server.markdown
@@ -39,9 +39,7 @@ The following arguments are supported:
 
 * `deployment_href` - (Required) The href of the deployment the server will be placed in.
 
-* `instance` - (Required) See [rightscale_instance](https://github.com/terraform-providers/terraform-provider-rightscale/blob/master/website/docs/r/cm_instance.markdown)
-
-* `cloud_href` - (Required) The Href of the cloud the server will be launched in.
+* `instance` - (Required) See [rightscale_instance](./cm_instance.html).
 
 * `description` - (Optional) A description of the server.
 


### PR DESCRIPTION
- The `cloud_href` key/argument is not actually set on the `rightscale_server` resource, it is instead set on the `instance` sub key.
- Make the `rightscale_instance` link relative so it stays on the docs site instead of going to GitHub.